### PR TITLE
readme: mention openssl prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ cargo run --release -- -h
 
 - [Rust](https://www.rust-lang.org/)
 - [Docker](https://www.docker.com/)
+- [OpenSSL](https://www.openssl.org/)
 
 Create Docker network:
 


### PR DESCRIPTION
don't know if you want to add this to the README, but openssl is required, else this error will be thrown:
```
The system library `openssl` required by crate `openssl-sys` was not
found.
```