### PR TITLE
zig/computation: improve performance

### DIFF
--- a/benchmark/computation/zig/zig-0.14/src/main.zig
+++ b/benchmark/computation/zig/zig-0.14/src/main.zig
@@ -3,16 +3,12 @@ const net = std.net;
 const http = std.http;
 
 pub fn main() !void {
-    var gpa = std.heap.DebugAllocator(.{}).init;
-    const allocator = gpa.allocator();
-    defer _ = gpa.deinit();
-
     const addr = net.Address.parseIp4("0.0.0.0", 3000) catch unreachable;
     var server = try addr.listen(.{});
-    start_server(allocator, &server);
+    start_server(&server);
 }
 
-fn start_server(allocator: std.mem.Allocator, server: *net.Server) void {
+fn start_server(server: *net.Server) void {
     while (true) {
         var connection = server.accept() catch unreachable;
         defer connection.stream.close();
@@ -22,15 +18,16 @@ fn start_server(allocator: std.mem.Allocator, server: *net.Server) void {
         var http_server = http.Server.init(connection, &read_buffer);
 
         var request = http_server.receiveHead() catch unreachable;
-        handle_request(allocator, &request) catch unreachable;
+        handle_request(&request) catch unreachable;
     }
 }
 
-fn handle_request(allocator: std.mem.Allocator, request: *http.Server.Request) !void {
+fn handle_request(request: *http.Server.Request) !void {
     const parameter = request.head.target[13..];
     const iterations = try std.fmt.parseUnsigned(u32, parameter, 10);
     const result = calc_pi(iterations);
-    const formatted_result = try std.fmt.allocPrint(allocator, "{d};{d};{d}", .{ result.pi, result.sum, result.alt_sum });
+    var buf: [1024]u8 = undefined;
+    const formatted_result = try std.fmt.bufPrint(&buf, "{d};{d};{d}", .{ result.pi, result.sum, result.alt_sum });
     try request.respond(formatted_result, .{});
 }
 


### PR DESCRIPTION
instead of passing an allocator along to allocate memory and construct the result response, a buffer should suffice

the allocator wasn't chosen with care anyway

this improves speed and memory usage