### PR TITLE
disable tracing for rama benchmarks

### DIFF
--- a/benchmark/web/rust/rama-0.2-rust-1.86/Cargo.toml
+++ b/benchmark/web/rust/rama-0.2-rust-1.86/Cargo.toml
@@ -5,10 +5,16 @@ edition = "2024"
 publish = false
 rust-version = "1.86.0"
 
+[features]
+default = []
+tracing = ["dep:tracing", "dep:tracing-subscriber"]
+
 [dependencies]
 rama = { version = "0.2.0-alpha.13", features = ["http-full", "compression"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3", features = [
+    "env-filter",
+], optional = true }


### PR DESCRIPTION
noticed that rama is the only rust benchmark with
a tracing subscriber. So Disabling it by default, but leaving it behind a feature flag if we ever need it for debugging purposes

this improves the performance a bit as well