### PR TITLE
benchmark: add zig httpz / http.zig web benchmark

### DIFF
--- a/benchmark/web/zig/httpz-0.15/Dockerfile
+++ b/benchmark/web/zig/httpz-0.15/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:edge
+
+WORKDIR /app
+COPY src ./src
+COPY build.zig ./build.zig
+
+EXPOSE 3000
+
+RUN apk add zig=0.15.2-r0
+RUN zig fetch --save "git+https://github.com/karlseguin/http.zig#af1df361d599dbc3f9534b0183a8b5e3fe2af83e"
+RUN zig build --release=fast
+
+CMD ["./zig-out/bin/benchmark"]

--- a/benchmark/web/zig/httpz-0.15/benchmark.yaml
+++ b/benchmark/web/zig/httpz-0.15/benchmark.yaml
@@ -1,0 +1,9 @@
+language: Zig
+mode: Default
+version:
+  - '0.15.2'
+framework: httpz
+framework_website: https://github.com/karlseguin/http.zig
+framework_flavor: Default
+framework_version:
+  - 'af1df361d599dbc3f9534b0183a8b5e3fe2af83e'

--- a/benchmark/web/zig/httpz-0.15/build.zig
+++ b/benchmark/web/zig/httpz-0.15/build.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe_mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "benchmark",
+        .root_module = exe_mod,
+    });
+
+    b.installArtifact(exe);
+
+    // http.zig
+    const httpz = b.dependency("httpz", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // the executable from your call to b.addExecutable(...)
+    exe.root_module.addImport("httpz", httpz.module("httpz"));
+}

--- a/benchmark/web/zig/httpz-0.15/build.zig.zon
+++ b/benchmark/web/zig/httpz-0.15/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = .httpz_0_15,
+    .version = "0.0.0",
+    .fingerprint = 0xe2b86e5f6f5bb385, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.15.2",
+    .dependencies = .{
+        .httpz = .{
+            .url = "git+https://github.com/karlseguin/http.zig#af1df361d599dbc3f9534b0183a8b5e3fe2af83e",
+            .hash = "httpz-0.0.0-PNVzrMpOBwCS42DpyNnY8WTlwcuzannBeDLuqkUV8H7-",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/benchmark/web/zig/httpz-0.15/src/main.zig
+++ b/benchmark/web/zig/httpz-0.15/src/main.zig
@@ -1,0 +1,121 @@
+const std = @import("std");
+const httpz = @import("httpz");
+
+const Handler = struct {
+    client: std.http.Client,
+};
+
+const ElementResponse = struct {
+    name: []const u8,
+    number: i64,
+    group: i64,
+};
+
+const ShellsResponse = struct {
+    shells: []i64,
+};
+
+fn getElement(handler: *Handler, req: *httpz.Request, res: *httpz.Response) !void {
+    const query = try req.query();
+    const symbol = query.get("symbol").?;
+
+    const uri = try std.Uri.parse("http://web-data-source/element.json");
+
+    var data_req = try handler.client.request(.GET, uri, .{});
+    defer data_req.deinit();
+
+    try data_req.sendBodiless();
+    var data_res = try data_req.receiveHead(&.{});
+
+    var reader_buffer: [9 * 1024]u8 = undefined;
+    const body_reader = data_res.reader(&reader_buffer);
+    const response_body = try body_reader.allocRemaining(res.arena, .limited(reader_buffer.len));
+
+    // use std.json.parseFromSliceLeaky because an arena allocator is used
+    const parsed = try std.json.parseFromSliceLeaky(
+        std.json.Value,
+        res.arena,
+        response_body,
+        .{},
+    );
+
+    // const element_object = parsed.object.get(symbol).?;
+    const element_object = parsed.object.get(symbol).?;
+    const element_res = ElementResponse{
+        .name = element_object.object.get("name").?.string,
+        .number = element_object.object.get("number").?.integer,
+        .group = element_object.object.get("group").?.integer,
+    };
+
+    res.status = 200;
+    try res.json(element_res, .{});
+}
+
+fn getShells(handler: *Handler, req: *httpz.Request, res: *httpz.Response) !void {
+    const query = try req.query();
+    const symbol = query.get("symbol").?;
+
+    const uri = try std.Uri.parse("http://web-data-source/shells.json");
+
+    var data_req = try handler.client.request(.GET, uri, .{});
+    defer data_req.deinit();
+
+    try data_req.sendBodiless();
+    var data_res = try data_req.receiveHead(&.{});
+
+    var reader_buffer: [4 * 1024]u8 = undefined;
+    const body_reader = data_res.reader(&reader_buffer);
+    const body = try body_reader.allocRemaining(res.arena, .limited(reader_buffer.len));
+
+    // use std.json.parseFromSliceLeaky because an arena allocator is used
+    const parsed = try std.json.parseFromSliceLeaky(
+        std.json.Value,
+        res.arena,
+        body,
+        .{},
+    );
+
+    // const shells_object = parsed.object.get(symbol).?.array;
+    const shells_object = parsed.object.get(symbol).?.array;
+    var shells = try res.arena.alloc(i64, shells_object.items.len);
+
+    for (shells_object.items, 0..) |item, index| {
+        shells[index] = item.integer;
+    }
+
+    const shells_res = ShellsResponse{
+        .shells = shells,
+    };
+
+    res.status = 200;
+    try res.json(shells_res, .{});
+}
+
+pub fn main() !void {
+    var gpa = std.heap.DebugAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var client = std.http.Client{ .allocator = allocator };
+    defer client.deinit();
+
+    var handler = Handler{ .client = client };
+    var server = try httpz.Server(*Handler).init(allocator, .{
+        .address = .{
+            .addr = .initIp4(.{ 0, 0, 0, 0 }, 3000),
+        },
+    }, &handler);
+
+    defer {
+        // clean shutdown, finishes serving any live request
+        server.stop();
+        server.deinit();
+    }
+
+    var router = try server.router(.{});
+    router.get("/api/v1/periodic-table/element", getElement, .{});
+    router.get("/api/v1/periodic-table/shells", getShells, .{});
+
+    // blocks
+    try server.listen();
+}


### PR DESCRIPTION
I gave adding https://github.com/karlseguin/http.zig to the web benchmarks a try.
I am not sure, but feel like this should be quite a bit faster, so I will draft for now and continue to look for pitfalls I might have fallen into.
Still wanted to release this as a draft, so other people can take a look as well.
If you find a flaw in my implementation, please let me know.

E.g. at first I was initialising the `std.http.Client`, which requests the web-data, anew on every request. Initialising this client once and passing it around in handler / context, increased the achieved median rpm from around 270 to around 4350.
This is where performance sits right now, but I fear I might have made more such mistakes.