### PR TITLE
Add Echo Go web benchmark

### DIFF
--- a/benchmark/frameworks.yaml
+++ b/benchmark/frameworks.yaml
@@ -49,6 +49,11 @@ Drogon: >
   comprehensive features including ORM support, WebSocket handling, and
   middleware. Drogon is designed for developers who need maximum performance
   and control in C++ web applications.
+Echo: >
+  Echo is a high-performance, extensible web framework for Go focused on
+  building HTTP APIs and services with a small core. It provides fast routing,
+  middleware support, request binding, validation hooks, and flexible response
+  helpers while staying close to Go's standard net/http model.
 Express: >
   Express is a minimal and flexible Node.js web application framework that
   provides a robust set of features for web and mobile applications. It has

--- a/benchmark/web/go/echo-4-go-1.20/Dockerfile
+++ b/benchmark/web/go/echo-4-go-1.20/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.20
+
+WORKDIR /app
+COPY . .
+
+RUN go get main
+
+RUN go build -o main .
+
+RUN chmod +x main
+
+EXPOSE 3000
+CMD ["./main"]

--- a/benchmark/web/go/echo-4-go-1.20/benchmark.yaml
+++ b/benchmark/web/go/echo-4-go-1.20/benchmark.yaml
@@ -1,0 +1,10 @@
+language: Go
+mode: Default
+version:
+  - '1.20'
+  - '1.24'
+framework: Echo
+framework_website: https://echo.labstack.com/
+framework_flavor: Default
+framework_version:
+  - '4'

--- a/benchmark/web/go/echo-4-go-1.20/go.mod
+++ b/benchmark/web/go/echo-4-go-1.20/go.mod
@@ -1,0 +1,7 @@
+module main
+
+require (
+	github.com/goccy/go-json v0.10.3
+	github.com/labstack/echo/v4 v4.13.3
+	github.com/valyala/fasthttp v1.54.0
+)

--- a/benchmark/web/go/echo-4-go-1.20/main.go
+++ b/benchmark/web/go/echo-4-go-1.20/main.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/goccy/go-json"
+	"github.com/labstack/echo/v4"
+	"github.com/valyala/fasthttp"
+)
+
+var (
+	client = &fasthttp.Client{}
+)
+
+func main() {
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+	e.JSONSerializer = goccyJSONSerializer{}
+
+	e.GET("/api/v1/periodic-table/element", getElement)
+	e.GET("/api/v1/periodic-table/shells", getShells)
+
+	e.Start("0.0.0.0:3000")
+}
+
+type goccyJSONSerializer struct{}
+
+func (goccyJSONSerializer) Serialize(c echo.Context, i interface{}, indent string) error {
+	var (
+		body []byte
+		err  error
+	)
+
+	if indent == "" {
+		body, err = json.Marshal(i)
+	} else {
+		body, err = json.MarshalIndent(i, "", indent)
+	}
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Response().Write(body)
+	return err
+}
+
+func (goccyJSONSerializer) Deserialize(c echo.Context, i interface{}) error {
+	return json.NewDecoder(c.Request().Body).Decode(i)
+}
+
+type Element struct {
+	Name   string `json:"name"`
+	Number int    `json:"number"`
+	Group  int    `json:"group"`
+}
+
+type ShellsResponse struct {
+	Shells []int `json:"shells"`
+}
+
+type ElementsData map[string]Element
+type ShellsData map[string][]int
+
+func getElement(c echo.Context) error {
+	symbol := c.QueryParam("symbol")
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI("http://web-data-source/element.json")
+
+	client.Do(req, resp)
+	body := resp.Body()
+
+	var elements ElementsData
+	json.Unmarshal(body, &elements)
+
+	element := elements[symbol]
+
+	return c.JSON(http.StatusOK, element)
+}
+
+func getShells(c echo.Context) error {
+	symbol := c.QueryParam("symbol")
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI("http://web-data-source/shells.json")
+
+	client.Do(req, resp)
+	body := resp.Body()
+
+	var shellsData ShellsData
+	json.Unmarshal(body, &shellsData)
+
+	shells := shellsData[symbol]
+
+	return c.JSON(http.StatusOK, ShellsResponse{Shells: shells})
+}


### PR DESCRIPTION
## Summary

Adds an Echo v4 Go web benchmark alongside the existing Gin and FastHTTP implementations. The benchmark keeps the same periodic-table routes, data-source fetches, and response shapes while using Echo with a goccy/go-json serializer for efficient JSON handling.

Also adds Echo to the framework catalog metadata.